### PR TITLE
Panic when requiring coffeescript from app.js

### DIFF
--- a/asset.go
+++ b/asset.go
@@ -47,6 +47,10 @@ func ReadAsset(assetUrl string) (result string, err error) {
 }
 
 var patterns = map[string](map[string]*regexp.Regexp){
+	".coffee": map[string]*regexp.Regexp{
+		"head":    regexp.MustCompile(`(.*\n)*(\ *#\=\ *require\ +.*\n)+`),
+		"require": regexp.MustCompile(`^\ *#\=\ *require\ +`),
+	},
 	".js": map[string]*regexp.Regexp{
 		"head":    regexp.MustCompile(`(.*\n)*(\ *\/\/\=\ *require\ +.*\n)+`),
 		"require": regexp.MustCompile(`^\ *\/\/\=\ *require\ +`),


### PR DESCRIPTION
I have `/assets/javascripts/app.js` which is able to require any .js file. However when I add a require for any coffeescript file such as `/assets/javascripts/contestants.coffee`:

```coffeescript
//= require javascripts/contestants
```

The app panics in asset.go when I call `train.JavascriptTag("app")`:

```
2014/09/15 04:11:22 http: panic serving 127.0.0.1:52672: runtime error: invalid memory address or nil pointer dereference
goroutine 22 [running]:
net/http.func·011()
        /usr/local/Cellar/go/1.3.1/libexec/src/pkg/net/http/server.go:1100 +0xb7
runtime.panic(0x2df0a0, 0x4dd624)
        /usr/local/Cellar/go/1.3.1/libexec/src/pkg/runtime/panic.c:248 +0x18d
regexp.(*Regexp).get(0x0, 0x1)
        /usr/local/Cellar/go/1.3.1/libexec/src/pkg/regexp/regexp.go:192 +0x13e
regexp.(*Regexp).doExecute(0x0, 0x0, 0x0, 0xc20815f000, 0xee4, 0x1000, 0x314130, 0x0, 0x0, 0x2, ...)
        /usr/local/Cellar/go/1.3.1/libexec/src/pkg/regexp/exec.go:423 +0x5e
regexp.(*Regexp).Find(0x0, 0xc20815f000, 0xee4, 0x1000, 0x0, 0x0, 0x0)
        /usr/local/Cellar/go/1.3.1/libexec/src/pkg/regexp/regexp.go:664 +0xb3
github.com/shaoshing/train.FindDirectivesHeader(0xc208000c80, 0xc208023b7c, 0x7, 0x0, 0x0)
        /Users/nilbus/go/src/github.com/shaoshing/train/asset.go:119 +0x237
github.com/shaoshing/train.ReadAssetsFunc(0xc208023b60, 0x23, 0xc208054f00, 0x18, 0x3bedb8, 0x0, 0x0, 0x0, 0x0, 0x0)
        /Users/nilbus/go/src/github.com/shaoshing/train/asset.go:78 +0x44e
github.com/shaoshing/train.ReadAssetsFunc(0xc208054d40, 0x19, 0xc208054d20, 0x12, 0x3bedb8, 0xc208054e80, 0x2, 0x2, 0x0, 0x0)
        /Users/nilbus/go/src/github.com/shaoshing/train/asset.go:102 +0x908
github.com/shaoshing/train.getUnbundledAssets(0xc208054d20, 0x12, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /Users/nilbus/go/src/github.com/shaoshing/train/helpers.go:54 +0x19d
github.com/shaoshing/train.resolveAssetUrls(0xc208054d20, 0x12, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /Users/nilbus/go/src/github.com/shaoshing/train/helpers.go:44 +0x255
github.com/shaoshing/train.JavascriptTag(0x31f4f0, 0x3, 0x0, 0x0)
        /Users/nilbus/go/src/github.com/shaoshing/train/helpers.go:26 +0xa4
main.handler(0x596918, 0xc20803e0a0, 0xc208029110)
```

[asset.go:49](https://github.com/shaoshing/train/blob/9168e9603431570245c742cff975651af5fbcf94/asset.go#L49) defines `patterns`, which did not include patterns for the `".coffee"` extension. [`FindDirectivesHeader`](https://github.com/shaoshing/train/blob/9168e9603431570245c742cff975651af5fbcf94/asset.go#L113) in the above scenario does get called with `fileExt == ".coffee"`.

Though I tried, I have not been able to understand your tests well enough to be able to reproduce this scenario and cause the panic.

What are your thoughts on this?